### PR TITLE
feat: add gemini pricing

### DIFF
--- a/server/src/services/llm_pricing.py
+++ b/server/src/services/llm_pricing.py
@@ -5,6 +5,7 @@ LLMモデルの価格計算サービス
 
 class LLMPricing:
     """LLMモデルの価格計算クラス"""
+    DEFAULT_PRICE = {"input": 0, "output": 0}  # 不明なモデルは 0 = 情報なし
 
     PRICING: dict[str, dict[str, dict[str, float]]] = {
         "openai": {
@@ -22,9 +23,13 @@ class LLMPricing:
             "openai/gpt-4o-2024-08-06": {"input": 2.50, "output": 10.00},
             "google/gemini-2.5-pro-preview": {"input": 1.25, "output": 10.00},
         },
+        "gemini": {
+            "gemini-1.5-flash": {"input": 0.35, "output": 1.05},
+            "gemini-1.5-pro": {"input": 3.50, "output": 10.50},
+            # 価格情報未定のためDEFAULT_PRICEを利用
+            "gemini-2.5-pro-preview": DEFAULT_PRICE,
+        },
     }
-
-    DEFAULT_PRICE = {"input": 0, "output": 0}  # 不明なモデルは 0 = 情報なし
 
     @classmethod
     def calculate_cost(cls, provider: str, model: str, token_usage_input: int, token_usage_output: int) -> float:

--- a/server/tests/services/test_llm_pricing.py
+++ b/server/tests/services/test_llm_pricing.py
@@ -66,6 +66,18 @@ class TestLLMPricing:
         cost = LLMPricing.calculate_cost(provider, model, token_usage_input, token_usage_output)
         assert cost == pytest.approx(expected_cost)
 
+    def test_calculate_cost_gemini_flash(self):
+        """Geminiのgemini-1.5-flashモデルの料金計算が正しく行われる"""
+        provider = "gemini"
+        model = "gemini-1.5-flash"
+        token_usage_input = 1_000_000  # 1M tokens
+        token_usage_output = 500_000  # 0.5M tokens
+
+        expected_cost = 0.875
+
+        cost = LLMPricing.calculate_cost(provider, model, token_usage_input, token_usage_output)
+        assert cost == pytest.approx(expected_cost)
+
     def test_calculate_cost_unknown_provider(self):
         """不明なプロバイダーの場合は0"""
         provider = "unknown_provider"


### PR DESCRIPTION
## Summary
- add Google Gemini pricing table with default fallback for unknown rates
- test Gemini cost calculation

## Testing
- `python -m py_compile server/src/services/llm_pricing.py`
- `PYENV_VERSION=3.11.12 pytest tests/services/test_llm_pricing.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b3d342cccc83319bc90490cad67d1c