### PR TITLE
feat: add gemini provider option

### DIFF
--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -92,6 +92,7 @@ export function AISettingsSection({
             <option value={"openai"}>OpenAI</option>
             <option value={"azure"}>Azure</option>
             <option value={"openrouter"}>OpenRouter</option>
+            <option value={"gemini"}>Gemini</option>
             <option value={"local"}>LocalLLM</option>
           </NativeSelect.Field>
           <NativeSelect.Indicator />

--- a/client-admin/app/create/hooks/useAISettings.ts
+++ b/client-admin/app/create/hooks/useAISettings.ts
@@ -1,7 +1,7 @@
 import { toaster } from "@/components/ui/toaster";
 import { type ChangeEvent, useEffect, useState } from "react";
 
-export type Provider = "openai" | "azure" | "openrouter" | "local";
+export type Provider = "openai" | "azure" | "openrouter" | "gemini" | "local";
 
 export interface ModelOption {
   value: string;
@@ -38,6 +38,11 @@ const OPENROUTER_MODELS: ModelOption[] = [
   { value: "openai/gpt-4o-2024-08-06", label: "GPT-4o (OpenRouter)" },
   { value: "openai/gpt-4o-mini-2024-07-18", label: "GPT-4o mini (OpenRouter)" },
   { value: "google/gemini-2.5-pro-preview", label: "Gemini 2.5 Pro" },
+];
+
+const GEMINI_MODELS: ModelOption[] = [
+  { value: "gemini-1.5-flash", label: "Gemini 1.5 Flash" },
+  { value: "gemini-1.5-pro", label: "Gemini 1.5 Pro" },
 ];
 
 /**
@@ -213,6 +218,10 @@ export function useAISettings() {
       models: OPENROUTER_MODELS,
       description: "OpenRouterを使用して複数のモデルにアクセスします。",
     },
+    gemini: {
+      models: GEMINI_MODELS,
+      description: "Google Gemini APIを使用します。GoogleのAPIキーが必要です。",
+    },
     local: {
       models: localLLMModels,
       description: "ローカルで実行されているLLMサーバーに接続します。",
@@ -296,6 +305,14 @@ export function useAISettings() {
       }
       if (model === "o3-mini") {
         return "o3-mini：gpt-4oよりも高度な推論能力を備えたモデルです。性能はより高くなりますが、gpt-4oと比較してOpenAI APIの料金は高くなります。";
+      }
+    }
+    if (provider === "gemini") {
+      if (model === "gemini-1.5-flash") {
+        return "Gemini 1.5 Flash：高速かつコスト効率の高いモデルです。";
+      }
+      if (model === "gemini-1.5-pro") {
+        return "Gemini 1.5 Pro：高度な推論能力を備えたモデルです。";
       }
     }
     return "";


### PR DESCRIPTION
## Summary
- add Gemini provider and models to AI settings
- support Gemini model descriptions
- expose Gemini in provider selection UI

## Testing
- `npx biome check client-admin/app/create/hooks/useAISettings.ts client-admin/app/create/components/AISettingsSection.tsx` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*
- `npm install @biomejs/cli-linux-x64@1.9.4` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@biomejs%2fcli-linux-x64)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d343f13c8331bd0b05d39a41ed40