### PR TITLE
Add Gemini API support and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 OPENAI_API_KEY=
 # OpenRouterのAPIキー。OpenRouterアカウント上でAPIキーを発行して記載。
 OPENROUTER_API_KEY=
+# GeminiのAPIキー。Google AI Studio上でAPIキーを発行して記載。
+GOOGLE_API_KEY=
 # clientからAPIにアクセスする際のAPIキー。サーバー側でセットされる。NEXT_PUBLIC_PUBLIC_API_KEYと同じ値を設定。
 PUBLIC_API_KEY=public
 # client-adminからAPIにアクセスする際のAPIキー。サーバー側でセットされる。NEXT_PUBLIC_ADMIN_API_KEYと同じ値を設定。

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@
 - 一般ユーザー向け：
   - 安定版リリースをダウンロード（[Windows](./docs/windows-setup.md)/[Mac](./docs/mac-setup.md)/[Linux](./docs/linux-setup.md)の各ガイドを参照）
   - Docker（各ガイドに従ってインストール）
-  - OpenAI API キー
+- OpenAI API キー
+- Gemini API キー（[取得方法](https://ai.google.dev/gemini-api/docs/api-key)）
 - 開発者向け：
   - docker
   - git
-  - OpenAI API キー
+- OpenAI API キー
+- Gemini API キー（[取得方法](https://ai.google.dev/gemini-api/docs/api-key)）
 
 ## セットアップ・起動
 
@@ -55,7 +57,7 @@
 - 開発者向け：
   - リポジトリをクローン
   - `cp .env.example .env` をコンソールで実行
-    - コピー後に各環境変数を設定。各環境変数の意味は.env.example に記載。
+    - コピー後に `OPENAI_API_KEY` や `GOOGLE_API_KEY` を含む各環境変数を設定。各環境変数の意味は .env.example に記載。
   - `docker compose up` をコンソールで実行
     - ブラウザで http://localhost:3000 にアクセスすることでレポート一覧画面にアクセス可能
     - ブラウザで http://localhost:4000 にアクセスすることで管理画面にアクセス可能
@@ -94,6 +96,19 @@ GPU を搭載したマシンでローカル LLM を使用したい場合は、�
 
 - ローカル LLM の使用には十分な GPU メモリが必要です（8GB 以上推奨）
 - 初回起動時にはモデルのダウンロードに時間がかかる場合があります
+
+### Gemini API の設定
+
+- [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key) で API キーを取得し、`.env` に `GOOGLE_API_KEY` として設定します。
+- 利用可能なモデル例: `gemini-1.5-flash`, `gemini-1.5-pro`
+- Python からの利用例:
+  ```python
+  import google.generativeai as genai
+
+  genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
+  model = genai.GenerativeModel("gemini-1.5-flash")
+  print(model.generate_content("こんにちは、世界！").text)
+  ```
 
 ### Google Analytics の設定
 

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -8,6 +8,7 @@
 - Ubuntu 20.04 LTS 以降（または同等のLinuxディストリビューション）
 - インターネット接続
 - OpenAI APIキー（[取得方法](https://platform.openai.com/api-keys)）
+- Gemini APIキー（[取得方法](https://ai.google.dev/gemini-api/docs/api-key)）
 
 ## セットアップ手順
 
@@ -32,10 +33,11 @@ sudo usermod -aG docker $USER
 unzip ダウンロードしたzipファイル -d 展開先のパス
 ```
 
-### 3. OpenAI APIキーの準備
+### 3. APIキーの準備
 
-1. [OpenAI API](https://platform.openai.com/api-keys)にアクセスし、APIキーを取得します。
-2. アカウントに$5程度のクレジットをチャージしておくことをお勧めします。
+1. [OpenAI API](https://platform.openai.com/api-keys)にアクセスし、OpenAI APIキーを取得します（OpenAIモデルを使用する場合）。
+2. [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key)にアクセスし、Gemini APIキーを取得します（Geminiモデルを使用する場合）。
+3. 各サービスの利用には課金が発生する場合があります。事前にクレジットをチャージしておくことをお勧めします。
 
 ### 4. セットアップの実行
 
@@ -43,7 +45,7 @@ unzip ダウンロードしたzipファイル -d 展開先のパス
 2. 展開したフォルダに移動します：`cd 展開したフォルダのパス`
 3. セットアップスクリプトに実行権限を付与します：`chmod +x setup_linux.sh`
 4. 以下のコマンドを実行してセットアップを開始します：`./setup_linux.sh`
-5. プロンプトが表示されたら、OpenAI APIキーを入力します。
+5. プロンプトが表示されたら、OpenAI APIキーとGemini APIキーを入力します（どちらか一方でも可）。
 6. セットアップが自動的に進行し、Dockerコンテナが起動します。
 
 ### 5. アプリケーションへのアクセス
@@ -65,12 +67,12 @@ unzip ダウンロードしたzipファイル -d 展開先のパス
 - アプリケーションの停止:  
   `./stop_linux.sh` を実行します
 
-#### OpenAI APIキーを変更したい場合
+#### APIキーを変更したい場合
 
-OpenAI APIキーを再設定したい場合は、再度 `./setup_linux.sh` を実行してください。
+OpenAI APIキーやGemini APIキーを再設定したい場合は、再度 `./setup_linux.sh` を実行してください。
 
 1. 既存のアプリケーションが起動中の場合は `./stop_linux.sh` で停止してください。  
-2. `./setup_linux.sh` を実行し、新しい APIキーを入力します。  
+2. `./setup_linux.sh` を実行し、新しい APIキーを入力します。
 3. 自動的に再ビルドと起動が行われます。
 
 > ※ `setup_linux.sh` の再実行では、既存の `.env` ファイルが上書きされます。

--- a/docs/mac-setup.md
+++ b/docs/mac-setup.md
@@ -8,6 +8,7 @@
 - macOS Catalina (10.15) 以降
 - インターネット接続
 - OpenAI APIキー（[取得方法](https://platform.openai.com/api-keys)）
+- Gemini APIキー（[取得方法](https://ai.google.dev/gemini-api/docs/api-key)）
 
 ## セットアップ手順
 
@@ -22,10 +23,11 @@
 1. [広聴AI安定版リリース](https://github.com/digitaldemocracy2030/kouchou-ai/releases/latest)から最新の安定版をダウンロードします。
 2. ダウンロードしたzipファイルを任意の場所に展開します。
 
-### 3. OpenAI APIキーの準備
+### 3. APIキーの準備
 
-1. [OpenAI API](https://platform.openai.com/api-keys)にアクセスし、APIキーを取得します。
-2. アカウントに$5程度のクレジットをチャージしておくことをお勧めします。
+1. [OpenAI API](https://platform.openai.com/api-keys)にアクセスし、OpenAI APIキーを取得します（OpenAIモデルを使用する場合）。
+2. [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key)にアクセスし、Gemini APIキーを取得します（Geminiモデルを使用する場合）。
+3. 各サービスの利用には課金が発生する場合があります。事前にクレジットをチャージしておくことをお勧めします。
 
 ### 4. セットアップの実行
 
@@ -33,7 +35,7 @@
 2. 展開したフォルダに移動します：`cd 展開したフォルダのパス`
 3. セットアップスクリプトに実行権限を付与します：`chmod +x setup_mac.sh`
 4. 以下のコマンドを実行してセットアップを開始します：`./setup_mac.sh`
-5. プロンプトが表示されたら、OpenAI APIキーを入力します。
+5. プロンプトが表示されたら、OpenAI APIキーとGemini APIキーを入力します（どちらか一方でも可）。
 6. セットアップが自動的に進行し、Dockerコンテナが起動します。
 
 ### 5. アプリケーションへのアクセス
@@ -55,12 +57,12 @@
 - アプリケーションの停止:  
   `./stop_mac.sh` を実行します（または Docker デスクトップから操作）
 
-#### OpenAI APIキーを変更したい場合
+#### APIキーを変更したい場合
 
-OpenAI APIキーを再設定したい場合は、再度 `./setup_mac.sh` を実行してください。
+OpenAI APIキーやGemini APIキーを再設定したい場合は、再度 `./setup_mac.sh` を実行してください。
 
 1. 既存のアプリケーションが起動中の場合は `./stop_mac.sh` で停止してください。  
-2. `./setup_mac.sh` を実行し、新しい APIキーを入力します。  
+2. `./setup_mac.sh` を実行し、新しい APIキーを入力します。
 3. 自動的に再ビルドと起動が行われます。
 
 > ※ `setup_mac.sh` の再実行では、既存の `.env` ファイルが上書きされます。

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -8,6 +8,7 @@
 - Windows 10/11
 - インターネット接続
 - OpenAI APIキー（[取得方法](https://platform.openai.com/api-keys)）
+- Gemini APIキー（[取得方法](https://ai.google.dev/gemini-api/docs/api-key)）
 
 ## セットアップ手順
 
@@ -23,17 +24,17 @@
 1. [広聴AI安定版リリース](https://github.com/digitaldemocracy2030/kouchou-ai/releases/latest)から最新の安定版をダウンロードします。
 2. ダウンロードしたzipファイルを任意の場所に展開します。
 
-### 3. OpenAI APIキーの準備
+### 3. APIキーの準備
 
-1. [OpenAI API](https://platform.openai.com/api-keys)にアクセスし、APIキーを取得します。
-2. アカウントに$5程度のクレジットをチャージしておくことをお勧めします。
+1. [OpenAI API](https://platform.openai.com/api-keys)にアクセスし、OpenAI APIキーを取得します（OpenAIモデルを使用する場合）。
+2. [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key)にアクセスし、Gemini APIキーを取得します（Geminiモデルを使用する場合）。
 3. APIキーをコピーして、メモ帳などに一時的に保存しておくと便利です。
 4. **重要**: APIキーは正確にコピーしてください。入力ミスがあると、後の処理でエラーが発生します。
 
 ### 4. セットアップの実行
 
 1. 展開したフォルダ内の`setup_win.bat`ファイルをダブルクリックします。
-2. プロンプトが表示されたら、OpenAI APIキーを入力します。
+2. プロンプトが表示されたら、OpenAI APIキーとGemini APIキーを入力します（どちらか一方でも可）。
    - **注意**: Ctrl+Vでの貼り付けができない場合は、右クリックして「貼り付け」を選択してください。
 3. セットアップが自動的に進行し、APIキーの有効性確認後にDockerコンテナが起動します。
 
@@ -56,12 +57,12 @@
 - アプリケーションの停止:  
   `stop_win.bat` をダブルクリックします（または Docker デスクトップから操作）
 
-#### OpenAI APIキーを変更したい場合
+#### APIキーを変更したい場合
 
-OpenAI APIキーを再設定したい場合は、再度 `setup_win.bat` を実行してください。
+OpenAI APIキーやGemini APIキーを再設定したい場合は、再度 `setup_win.bat` を実行してください。
 
 1. 既存のアプリケーションが起動中の場合は `stop_win.bat` で停止してください。  
-2. `setup_win.bat` を実行し、新しい APIキーを入力します。  
+2. `setup_win.bat` を実行し、新しい APIキーを入力します。
 3. 自動的に再ビルドと起動が行われます。
 
 > ※ `setup_win.bat` の再実行では、既存の `.env` ファイルが上書きされます。
@@ -76,10 +77,10 @@ OpenAI APIキーを再設定したい場合は、再度 `setup_win.bat` を実�
 
 Dockerをインストールした直後は、コマンドのパスが通っていない場合があります。コンピューターを再起動してから再度試してください。
 
-### OpenAI APIキーの入力に関する問題
+### APIキーの入力に関する問題
 
 - **貼り付けができない場合**: コマンドプロンプトではCtrl+Vが機能しないことがあります。右クリックして「貼り付け」を選択するか、Alt+Spaceキーを押してから「編集」→「貼り付け」を選択してください。
-- **APIキーが正しく動作しない場合**: APIキーが正確にコピーされているか確認してください。APIキーは「sk-」で始まり、その後に英数字が続きます。入力ミスがあると、後の処理でエラーが発生します。
+- **APIキーが正しく動作しない場合**: APIキーが正確にコピーされているか確認してください。OpenAI APIキーは「sk-」で始まります。入力ミスがあると、後の処理でエラーが発生します。
 
 ### WSL2の有効化が必要な場合
 

--- a/server/README.md
+++ b/server/README.md
@@ -7,6 +7,7 @@ kouchou-aiのAPIサーバーです。
 * rye
 * python 3.12
 * OpenAI API Key
+* Gemini API Key ([取得方法](https://ai.google.dev/gemini-api/docs/api-key))
 
 
 ## セットアップ（開発環境）
@@ -21,6 +22,18 @@ cp .env.example .env
 * OPENROUTER_API_KEY
   * OpenRouterのAPIキー。OpenRouter経由でOpenAIやGeminiのモデルを使用する場合に必要。
   * [OpenRouter](https://openrouter.ai/)でアカウントを作成し、APIキーを取得してください。
+* GOOGLE_API_KEY
+  * GeminiのAPIキー。[Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key)で取得し、Geminiモデルを直接利用する場合に設定。
+  * 利用例:
+    ```python
+    import os
+    import google.generativeai as genai
+
+    genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
+    model = genai.GenerativeModel("gemini-1.5-flash")
+    print(model.generate_content("Hello Gemini").text)
+    ```
+  * 利用可能なモデル例: `gemini-1.5-flash`, `gemini-1.5-pro`
 
 ※ APIキーは他人と共有しないでください。GithubやSlackにもアップロードしないよう注意してください。  
 ※ このキーを設定しなくてもサーバーは起動しますが、/admin/reportsなど一部のエンドポイントでエラーになります。  

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic-settings>=2.7.1",
     "pandas>=2.2.3",
     "openai>=1.77.0",
+    "google-generativeai==0.8.3",
     "litellm>=1.58.2",
     "python-dotenv>=1.0.1",
     "plotly>=5.24.1",

--- a/server/requirements.lock
+++ b/server/requirements.lock
@@ -64,6 +64,8 @@ frozenlist==1.6.0
 fsspec==2025.3.2
     # via huggingface-hub
     # via torch
+google-generativeai==0.8.3
+    # via server
 h11==0.16.0
     # via httpcore
     # via uvicorn

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -8,10 +8,12 @@ if ! docker info > /dev/null 2>&1; then
   exit 1
 fi
 
-read -p "Enter your OpenAI API key: " OPENAI_API_KEY
+read -p "Enter your OpenAI API key (optional): " OPENAI_API_KEY
+read -p "Enter your Gemini API key (optional): " GOOGLE_API_KEY
 
 cat > .env << EOL
 OPENAI_API_KEY=${OPENAI_API_KEY}
+GOOGLE_API_KEY=${GOOGLE_API_KEY}
 PUBLIC_API_KEY=public
 ADMIN_API_KEY=admin
 ENVIRONMENT=development

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -8,10 +8,12 @@ if ! docker info > /dev/null 2>&1; then
   exit 1
 fi
 
-read -p "Enter your OpenAI API key: " OPENAI_API_KEY
+read -p "Enter your OpenAI API key (optional): " OPENAI_API_KEY
+read -p "Enter your Gemini API key (optional): " GOOGLE_API_KEY
 
 cat > .env << EOL
 OPENAI_API_KEY=${OPENAI_API_KEY}
+GOOGLE_API_KEY=${GOOGLE_API_KEY}
 PUBLIC_API_KEY=public
 ADMIN_API_KEY=admin
 ENVIRONMENT=development

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -13,9 +13,13 @@ if %errorlevel% neq 0 (
 )
 
 REM Enter OpenAI API key
-echo OpenAI APIキーを入力してください。
+echo OpenAI APIキーを入力してください。（省略可）
 echo 注意: Ctrl+Vが機能しない場合は、右クリックして「貼り付け」を選択してください。
-set /p OPENAI_API_KEY=Enter your OpenAI API key: 
+set /p OPENAI_API_KEY=Enter your OpenAI API key:
+
+REM Enter Gemini API key
+echo Gemini APIキーを入力してください。（省略可）
+set /p GOOGLE_API_KEY=Enter your Gemini API key:
 
 REM Validate OpenAI API key format
 echo APIキーの形式を確認しています...
@@ -35,6 +39,7 @@ if %errorlevel% neq 0 (
 REM Generate .env file
 echo # Auto-generated .env file > .env
 echo OPENAI_API_KEY=%OPENAI_API_KEY% >> .env
+echo GOOGLE_API_KEY=%GOOGLE_API_KEY% >> .env
 echo PUBLIC_API_KEY=public >> .env
 echo ADMIN_API_KEY=admin >> .env
 echo ENVIRONMENT=development >> .env


### PR DESCRIPTION
## Summary
- add google-generativeai dependency to server
- document Gemini API key setup and usage examples across README files and platform guides
- update setup scripts to accept optional Gemini API key

## Testing
- `ruff check server`
- `pytest server` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b3d3450c688331ab6b26334094b468