### PR TITLE
docs: mention gemini provider in admin endpoints

### DIFF
--- a/server/src/routers/admin_report.py
+++ b/server/src/routers/admin_report.py
@@ -237,14 +237,16 @@ async def update_cluster_label(
 
 @router.get("/admin/models")
 async def get_models(
-    provider: str = Query(..., description="LLMプロバイダー名"),
+    provider: str = Query(
+        ..., description="LLMプロバイダー名 (openai, azure, openrouter, gemini, local)"
+    ),
     address: str | None = Query(None, description="LocalLLM用アドレス（例: 127.0.0.1:1234）"),
     api_key: str = Depends(verify_admin_api_key),
 ) -> list[dict[str, str]]:
     """指定されたプロバイダーのモデルリストを取得するエンドポイント
 
     Args:
-        provider: LLMプロバイダー名（openai, azure, openrouter, local）
+        provider: LLMプロバイダー名（openai, azure, openrouter, gemini, local）
         address: LocalLLM用アドレス（localプロバイダーの場合のみ使用、例: 127.0.0.1:1234）
         api_key: 管理者APIキー
 

--- a/server/src/schemas/admin_report.py
+++ b/server/src/schemas/admin_report.py
@@ -33,7 +33,7 @@ class ReportInput(SchemaBaseModel):
     is_pubcom: bool = False  # CSV出力モード出力フラグ
     inputType: Literal["file", "spreadsheet"] = "file"  # 入力タイプ
     is_embedded_at_local: bool = False  # エンベデッド処理をローカルで行うかどうか
-    provider: str = "openai"  # LLMプロバイダー（openai, azure, openrouter, local）
+    provider: str = "openai"  # LLMプロバイダー（openai, azure, openrouter, gemini, local）
     local_llm_address: str | None = None  # LocalLLM用アドレス（例: "127.0.0.1:1234"）
 
     # NOTE: team-mirai feature

--- a/server/src/schemas/report.py
+++ b/server/src/schemas/report.py
@@ -34,7 +34,7 @@ class Report(SchemaBaseModel):
     token_usage_input: int | None = None  # 入力トークン使用量
     token_usage_output: int | None = None  # 出力トークン使用量
     estimated_cost: float | None = None  # 推定コスト（USD）
-    provider: str | None = None  # LLMプロバイダー
+    provider: str | None = None  # LLMプロバイダー（openai, azure, openrouter, gemini, local）
     model: str | None = None  # LLMモデル
     analysis: AnalysisData | None = None
 


### PR DESCRIPTION
## Summary
- document gemini as an available LLM provider in admin report schema and admin models endpoint
- clarify allowed provider names in report schema

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi --break-system-packages` *(fails: Could not find a version that satisfies the requirement fastapi: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d345e60c8331a7622a68dff23295