### PR TITLE
Reset failure counter on successful poll

### DIFF
--- a/client-admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.test.ts
+++ b/client-admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.test.ts
@@ -143,7 +143,7 @@ describe("useReportProgressPoll", () => {
     });
   });
 
-  it("失敗したリクエストがmaxRetriesまでリトライされる", async () => {
+  it("失敗したリクエストが最大連続失敗回数までリトライされる", async () => {
     mockFetch
       .mockRejectedValueOnce(new Error("Network error"))
       .mockRejectedValueOnce(new Error("Network error"))
@@ -175,8 +175,8 @@ describe("useReportProgressPoll", () => {
     });
   });
 
-  it("最大リトライ回数後にエラーが設定される", async () => {
-    // maxRetriesより1多い11回の失敗した試行をモック
+  it("最大連続失敗回数後にエラーが設定される", async () => {
+    // maxConsecutiveFailuresより1多い11回の失敗した試行をモック
     for (let i = 0; i < 11; i++) {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/client-admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
+++ b/client-admin/app/_components/ReportCard/ProgressSteps/useReportProgressPolling.ts
@@ -12,8 +12,9 @@ export function useReportProgressPoll(slug: string) {
     if (!isPolling) return;
 
     let cancelled = false;
-    let retryCount = 0;
-    const maxRetries = 10;
+    // Count of consecutive failed polling attempts
+    let consecutiveFailureCount = 0;
+    const maxConsecutiveFailures = 10;
 
     async function poll() {
       if (cancelled) return;
@@ -30,10 +31,11 @@ export function useReportProgressPoll(slug: string) {
         });
 
         if (response.ok) {
+          // Reset failure count on any successful response
+          consecutiveFailureCount = 0;
           const data = await response.json();
 
           if (!data.current_step || data.current_step === "loading") {
-            retryCount = 0;
             setTimeout(poll, 3000);
             return;
           }
@@ -54,20 +56,20 @@ export function useReportProgressPoll(slug: string) {
           // 正常なレスポンスの場合は次のポーリングをスケジュール
           setTimeout(poll, 3000);
         } else {
-          retryCount++;
-          if (retryCount >= maxRetries) {
+          consecutiveFailureCount++;
+          if (consecutiveFailureCount >= maxConsecutiveFailures) {
             console.error("Maximum retry attempts reached");
             setIsError(true);
             setIsPolling(false);
             return;
           }
-          const retryInterval = retryCount < 3 ? 2000 : 5000;
+          const retryInterval = consecutiveFailureCount < 3 ? 2000 : 5000;
           setTimeout(poll, retryInterval);
         }
       } catch (error) {
         console.error("Polling error:", error);
-        retryCount++;
-        if (retryCount >= maxRetries) {
+        consecutiveFailureCount++;
+        if (consecutiveFailureCount >= maxConsecutiveFailures) {
           setIsError(true);
           setIsPolling(false);
           return;


### PR DESCRIPTION
## Summary
- reset consecutive failure counter for report progress polling when a request succeeds
- clarify retry logic tests to use consecutive failure terminology

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*


------
https://chatgpt.com/codex/tasks/task_e_68c6ce7a5ea48331a31d2bc278171639