### PR TITLE
Handle Gemini 2.5 Flash aliases in pricing

### DIFF
--- a/server/src/services/llm_pricing.py
+++ b/server/src/services/llm_pricing.py
@@ -48,11 +48,25 @@ class LLMPricing:
         if provider not in cls.PRICING:
             return cls._calculate_with_price(cls.DEFAULT_PRICE, token_usage_input, token_usage_output)
 
+        model = cls._normalize_model(provider, model)
+
         if model not in cls.PRICING[provider]:
             return cls._calculate_with_price(cls.DEFAULT_PRICE, token_usage_input, token_usage_output)
 
         price = cls.PRICING[provider][model]
         return cls._calculate_with_price(price, token_usage_input, token_usage_output)
+
+    @classmethod
+    def _normalize_model(cls, provider: str, model: str) -> str:
+        """既知のモデルIDに正規化する"""
+
+        if provider == "gemini":
+            normalized = model.removeprefix("models/")
+            if normalized.startswith("gemini-2.5-flash"):
+                return "gemini-2.5-flash"
+            return normalized
+
+        return model
 
     @staticmethod
     def _calculate_with_price(price: dict[str, float], token_usage_input: int, token_usage_output: int) -> float:

--- a/server/tests/services/test_llm_pricing.py
+++ b/server/tests/services/test_llm_pricing.py
@@ -78,6 +78,27 @@ class TestLLMPricing:
         cost = LLMPricing.calculate_cost(provider, model, token_usage_input, token_usage_output)
         assert cost == pytest.approx(expected_cost)
 
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "models/gemini-2.5-flash",
+            "gemini-2.5-flash-001",
+            "models/gemini-2.5-flash-001",
+            "models/gemini-2.5-flash-latest",
+        ],
+    )
+    def test_calculate_cost_gemini_25_flash_aliases(self, model):
+        """Gemini 2.5 Flashの異なるモデルIDでも料金計算が行われる"""
+
+        provider = "gemini"
+        token_usage_input = 1_000_000  # 1M tokens
+        token_usage_output = 500_000  # 0.5M tokens
+
+        expected_cost = 0.875
+
+        cost = LLMPricing.calculate_cost(provider, model, token_usage_input, token_usage_output)
+        assert cost == pytest.approx(expected_cost)
+
     def test_calculate_cost_unknown_provider(self):
         """不明なプロバイダーの場合は0"""
         provider = "unknown_provider"


### PR DESCRIPTION
## Summary
- normalize Gemini model identifiers so that Gemini 2.5 Flash variants share the existing pricing
- add unit test coverage to ensure Gemini 2.5 Flash aliases are billed at the expected rate

## Testing
- pytest server/tests/services/test_llm_pricing.py *(fails: ModuleNotFoundError: No module named 'fastapi'; package installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cee2dba3d08331ad092e8c642a1e65